### PR TITLE
The config allows setting webhooks to use POST method

### DIFF
--- a/config/config.reference.hocon
+++ b/config/config.reference.hocon
@@ -81,7 +81,8 @@
   # Optional webhooks configuration
   "webhooks": {
     # Enable webhooks that will be called when a schema is published or updated
-    # with a vendor that matches the specified prefixes
+    # with a vendor that matches the specified prefixes, allowing to use the
+    # http GET (by default) or POST method.
     "schemaPublished": [
       # {
       #   uri = "https://example.com/endpoint"
@@ -90,6 +91,10 @@
       #   uri = "https://example2.com/endpoint",
       #   vendorPrefixes = ["com", "org.acme", "org.snowplow"]
       # }
+      # {
+      #   uri = "https://example.com/endpoint",
+      #   usePost = true
+      # },
     ]
   }
 

--- a/src/main/scala/com/snowplowanalytics/iglu/server/Config.scala
+++ b/src/main/scala/com/snowplowanalytics/iglu/server/Config.scala
@@ -237,7 +237,12 @@ object Config {
         case keyCur if keyCur.isUndefined => List.empty.asRight
         case keyCur                       => keyCur.asList.flatMap(_.traverse(cur => cur.asString))
       }
-    } yield Webhook.SchemaPublished(uri, Some(prefixes))
+
+      usePost <- objCur.atKeyOrUndefined("usePost") match {
+        case keyCur if keyCur.isUndefined => None.asRight
+        case keyCur                       => ConfigReader[Option[Boolean]].from(keyCur)
+      }
+    } yield Webhook.SchemaPublished(uri, Some(prefixes), usePost.getOrElse(false))
   }
 
   implicit val pureStorageReader: ConfigReader[StorageConfig] = ConfigReader.fromCursor { cur =>

--- a/src/main/scala/com/snowplowanalytics/iglu/server/Webhook.scala
+++ b/src/main/scala/com/snowplowanalytics/iglu/server/Webhook.scala
@@ -23,24 +23,31 @@ import io.circe.generic.semiauto._
 import org.http4s.{Request, Response, Status, Uri}
 import org.http4s.client.Client
 import org.http4s.circe._
-
+import org.http4s.Method
 import com.snowplowanalytics.iglu.core.SchemaKey
 
 sealed trait Webhook
 
 object Webhook {
 
-  case class SchemaPublished(uri: Uri, vendorPrefixes: Option[List[String]]) extends Webhook
+  case class SchemaPublished(
+    uri: Uri,
+    vendorPrefixes: Option[List[String]],
+    usePost: Boolean
+  ) extends Webhook
 
   case class WebhookClient[F[_]](webhooks: List[Webhook], httpClient: Client[F]) {
     def schemaPublished(schemaKey: SchemaKey, updated: Boolean)(
       implicit F: BracketThrow[F]
     ): F[List[Either[String, Unit]]] =
       webhooks.traverse {
-        case SchemaPublished(uri, prefixes)
+        case SchemaPublished(uri, prefixes, usePost)
             if prefixes.isEmpty || prefixes.getOrElse(List()).exists(schemaKey.vendor.startsWith(_)) =>
           val event = SchemaPublishedEvent(schemaKey, updated)
-          val req   = Request[F]().withUri(uri).withBodyStream(Utils.toBytes(event))
+          val req = Request[F]()
+            .withUri(uri)
+            .withMethod(if (usePost) Method.POST else Method.GET)
+            .withBodyStream(Utils.toBytes(event))
           httpClient.run(req).use { res: Response[F] =>
             res.status match {
               case Status(code) if code < 200 || code > 299 => F.pure(code.toString.asLeft[Unit])

--- a/src/test/resources/valid-pg-config.conf
+++ b/src/test/resources/valid-pg-config.conf
@@ -66,7 +66,11 @@ webhooks = {
     {
       uri = "https://example2.com/endpoint",
       vendorPrefixes = ["com", "org.acme", "org.snowplow"]
-    }
+    },
+    {
+      uri = "https://example3.com/endpoint"
+      usePost = true
+    },
   ]
 }
 

--- a/src/test/scala/com/snowplowanalytics/iglu/server/ConfigSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/ConfigSpec.scala
@@ -75,8 +75,13 @@ class ConfigSpec extends org.specs2.Specification {
       true,
       true,
       List(
-        Webhook.SchemaPublished(uri"https://example.com/endpoint", Some(List.empty)),
-        Webhook.SchemaPublished(uri"https://example2.com/endpoint", Some(List("com", "org.acme", "org.snowplow")))
+        Webhook.SchemaPublished(uri"https://example.com/endpoint", Some(List.empty), usePost = false),
+        Webhook.SchemaPublished(
+          uri"https://example2.com/endpoint",
+          Some(List("com", "org.acme", "org.snowplow")),
+          usePost = false
+        ),
+        Webhook.SchemaPublished(uri"https://example3.com/endpoint", Some(List.empty), usePost = true)
       ),
       Config.Swagger("/custom/prefix"),
       None,
@@ -126,8 +131,12 @@ class ConfigSpec extends org.specs2.Specification {
       true,
       true,
       List(
-        Webhook.SchemaPublished(uri"https://example.com/endpoint", Some(List.empty)),
-        Webhook.SchemaPublished(uri"https://example2.com/endpoint", Some(List("com", "org.acme", "org.snowplow")))
+        Webhook.SchemaPublished(uri"https://example.com/endpoint", Some(List.empty), usePost = false),
+        Webhook.SchemaPublished(
+          uri"https://example2.com/endpoint",
+          Some(List("com", "org.acme", "org.snowplow")),
+          usePost = false
+        )
       ),
       Config.Swagger("/custom/prefix"),
       Some(UUID.fromString("a71aa7d9-6cde-40f7-84b1-046d65dedf9e")),
@@ -167,7 +176,8 @@ class ConfigSpec extends org.specs2.Specification {
           "SchemaPublished" : {
             "uri" : "https://example.com/endpoint",
             "vendorPrefixes" : [
-            ]
+            ],
+            "usePost": false
           }
         },
         {
@@ -177,7 +187,8 @@ class ConfigSpec extends org.specs2.Specification {
               "com",
               "org.acme",
               "org.snowplow"
-            ]
+            ],
+            "usePost": false
           }
         }
       ],

--- a/src/test/scala/com/snowplowanalytics/iglu/server/WebhookSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/WebhookSpec.scala
@@ -33,21 +33,26 @@ class WebhookSpec extends org.specs2.Specification {
     val response = WebhookSpec
       .webhookClient
       .schemaPublished(SchemaKey("com.acme", "event", "jsonschema", SchemaVer.Full(1, 0, 0)), true)
-    response.unsafeRunSync() mustEqual List(().asRight, ().asRight)
+    response.unsafeRunSync() mustEqual List(().asRight, ().asRight, ().asRight)
   }
 
   def e2 = {
     val response = WebhookSpec
       .badWebhookClient
       .schemaPublished(SchemaKey("com.acme", "event", "jsonschema", SchemaVer.Full(1, 0, 0)), true)
-    response.unsafeRunSync() mustEqual List("502".asLeft, "502".asLeft)
+    response.unsafeRunSync() mustEqual List("502".asLeft, "502".asLeft, "502".asLeft)
   }
 }
 
 object WebhookSpec {
   val webhooks = List(
-    Webhook.SchemaPublished(Uri.uri("https://example.com/endpoint"), None),
-    Webhook.SchemaPublished(Uri.uri("https://example2.com/endpoint"), Some(List("com", "org.acme", "org.snowplow")))
+    Webhook.SchemaPublished(Uri.uri("https://example.com/endpoint"), None, usePost = false),
+    Webhook.SchemaPublished(
+      Uri.uri("https://example2.com/endpoint"),
+      Some(List("com", "org.acme", "org.snowplow")),
+      usePost = false
+    ),
+    Webhook.SchemaPublished(Uri.uri("https://example3.com/endpoint"), None, usePost = true)
   )
 
   val client: Client[IO] = Client.fromHttpApp(HttpApp[IO](r => Response[IO]().withEntity(r.body).pure[IO]))


### PR DESCRIPTION
By default, while iglu-server invokes webhooks over the GET method, Iglu Webhook Adapter supports the POST method, let's allow each configured webhook to define whether POST method is required, such a setting is optional to keep backwards compatibility.

See: https://discourse.snowplow.io/t/support-for-post-payload-for-iglu-webhook-adapter/268