### PR TITLE
Fix superseding schema feature

### DIFF
--- a/src/main/scala/com/snowplowanalytics/iglu/server/Server.scala
+++ b/src/main/scala/com/snowplowanalytics/iglu/server/Server.scala
@@ -176,7 +176,7 @@ object Server {
       client   <- BlazeClientBuilder[IO](httpPool).resource
       webhookClient = Webhook.WebhookClient(config.webhooks, client)
       storage <- Storage.initialize[IO](config.database)
-      _       <- Resource.eval(storage.addSupersededByColumn)
+      _       <- Resource.eval(storage.runAutomaticMigrations)
       cache   <- CachingMiddleware.initResponseCache[IO](1000, CacheTtl)
       blocker <- Blocker[IO],
     } yield BlazeServerBuilder[IO](httpPool)

--- a/src/main/scala/com/snowplowanalytics/iglu/server/migrations/Bootstrap.scala
+++ b/src/main/scala/com/snowplowanalytics/iglu/server/migrations/Bootstrap.scala
@@ -62,7 +62,8 @@ END';"""
 
         body        JSON          NOT NULL,
 
-        superseded_by VARCHAR(128) NULL
+        superseded_by VARCHAR(32) NULL,
+        PRIMARY KEY(vendor, name, format, model, revision, addition)
       )""")
 
   val draftsCreate = (fr"CREATE TABLE IF NOT EXISTS" ++ Postgres.DraftsTable ++ fr"""(

--- a/src/main/scala/com/snowplowanalytics/iglu/server/migrations/Bootstrap.scala
+++ b/src/main/scala/com/snowplowanalytics/iglu/server/migrations/Bootstrap.scala
@@ -63,7 +63,7 @@ END';"""
         body        JSON          NOT NULL,
 
         superseded_by VARCHAR(32) NULL,
-        PRIMARY KEY(vendor, name, format, model, revision, addition)
+        supersedes VARCHAR(32) ARRAY NULL
       )""")
 
   val draftsCreate = (fr"CREATE TABLE IF NOT EXISTS" ++ Postgres.DraftsTable ++ fr"""(

--- a/src/main/scala/com/snowplowanalytics/iglu/server/migrations/Fifth.scala
+++ b/src/main/scala/com/snowplowanalytics/iglu/server/migrations/Fifth.scala
@@ -118,7 +118,7 @@ object Fifth {
     val previousPublic = schemas.forall(_.isPublic)
     val versions       = schemas.map(_.map.schemaKey.version)
     if ((previousPublic && isPublic) || (!previousPublic && !isPublic) || schemas.isEmpty)
-      VersionCursor.isAllowed(current.schemaKey.version, versions, patchesAllowed = false)
+      VersionCursor.isAllowed(current.schemaKey.version, versions, patchesAllowed = false, List.empty)
     else
       Inconsistency.Availability(isPublic, previousPublic).asLeft
   }

--- a/src/main/scala/com/snowplowanalytics/iglu/server/storage/Postgres.scala
+++ b/src/main/scala/com/snowplowanalytics/iglu/server/storage/Postgres.scala
@@ -34,6 +34,7 @@ import doobie.postgres.circe.json.implicits._
 import org.typelevel.log4cats.Logger
 
 import com.snowplowanalytics.iglu.core.{SchemaMap, SchemaVer}
+import com.snowplowanalytics.iglu.server.migrations.Bootstrap
 import com.snowplowanalytics.iglu.server.model.{Permission, Schema, SchemaDraft}
 import com.snowplowanalytics.iglu.server.model.SchemaDraft.DraftId
 
@@ -124,6 +125,8 @@ class Postgres[F[_]](xa: Transactor[F], logger: Logger[F]) extends Storage[F] { 
   def addSupersededByColumn(implicit F: Bracket[F, Throwable]): F[Unit] =
     logger.debug(s"addSupersededByColumn") *>
       Postgres.Sql.addSupersededByColumn.run.void.transact(xa)
+
+  def bootstrap(implicit F: Bracket[F, Throwable]): F[Int] = Bootstrap.initialize(xa)
 
   def updateSupersedingVersion(
     vendor: String,

--- a/src/main/scala/com/snowplowanalytics/iglu/server/storage/Storage.scala
+++ b/src/main/scala/com/snowplowanalytics/iglu/server/storage/Storage.scala
@@ -16,24 +16,18 @@ package com.snowplowanalytics.iglu.server
 package storage
 
 import java.util.UUID
-
 import fs2.Stream
-
 import cats.Monad
 import cats.effect.{Blocker, Bracket, BracketThrow, Clock, ContextShift, Effect, Resource, Sync}
 import cats.implicits._
-import cats.data.NonEmptyList
-
 import io.circe.Json
-
 import doobie.hikari._
 import doobie.util.transactor.Transactor
-
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.typelevel.log4cats.Logger
-
-import com.snowplowanalytics.iglu.core.{SchemaMap, SchemaVer}
+import com.snowplowanalytics.iglu.core.SchemaMap
 import com.snowplowanalytics.iglu.server.Config.StorageConfig
+import com.snowplowanalytics.iglu.server.model.Schema.SupersedingInfo
 import com.snowplowanalytics.iglu.server.model.{Permission, Schema, SchemaDraft}
 import com.snowplowanalytics.iglu.server.model.SchemaDraft.DraftId
 
@@ -81,13 +75,12 @@ trait Storage[F[_]] {
     } yield ()
   def deletePermission(id: UUID)(implicit F: Bracket[F, Throwable]): F[Unit]
 
-  def addSupersededByColumn(implicit F: Bracket[F, Throwable]): F[Unit]
+  def runAutomaticMigrations(implicit F: Bracket[F, Throwable]): F[Unit]
 
   def updateSupersedingVersion(
     vendor: String,
     name: String,
-    superseded: NonEmptyList[SchemaVer.Full],
-    supersededBy: SchemaVer.Full
+    supersedingInfo: SupersedingInfo.Pair
   )(implicit F: Bracket[F, Throwable]): F[Unit]
 }
 

--- a/src/main/scala/com/snowplowanalytics/iglu/server/storage/Storage.scala
+++ b/src/main/scala/com/snowplowanalytics/iglu/server/storage/Storage.scala
@@ -25,9 +25,8 @@ import doobie.hikari._
 import doobie.util.transactor.Transactor
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.typelevel.log4cats.Logger
-import com.snowplowanalytics.iglu.core.SchemaMap
+import com.snowplowanalytics.iglu.core.{SchemaMap, SchemaVer}
 import com.snowplowanalytics.iglu.server.Config.StorageConfig
-import com.snowplowanalytics.iglu.server.model.Schema.SupersedingInfo
 import com.snowplowanalytics.iglu.server.model.{Permission, Schema, SchemaDraft}
 import com.snowplowanalytics.iglu.server.model.SchemaDraft.DraftId
 
@@ -53,7 +52,7 @@ trait Storage[F[_]] {
   def getSchemasKeyOnly(implicit F: Bracket[F, Throwable]): F[List[(SchemaMap, Schema.Metadata)]]
   def getSchemaBody(schemaMap: SchemaMap)(implicit F: Bracket[F, Throwable]): F[Option[Json]] =
     getSchema(schemaMap).nested.map(_.body).value
-  def addSchema(schemaMap: SchemaMap, body: Json, isPublic: Boolean)(
+  def addSchema(schemaMap: SchemaMap, body: Json, isPublic: Boolean, supersedes: List[SchemaVer.Full])(
     implicit C: Clock[F],
     M: Bracket[F, Throwable]
   ): F[Unit]
@@ -76,12 +75,6 @@ trait Storage[F[_]] {
   def deletePermission(id: UUID)(implicit F: Bracket[F, Throwable]): F[Unit]
 
   def runAutomaticMigrations(implicit F: Bracket[F, Throwable]): F[Unit]
-
-  def updateSupersedingVersion(
-    vendor: String,
-    name: String,
-    supersedingInfo: SupersedingInfo.Pair
-  )(implicit F: Bracket[F, Throwable]): F[Unit]
 }
 
 object Storage {

--- a/src/test/scala/com/snowplowanalytics/iglu/server/ServerSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/ServerSpec.scala
@@ -37,7 +37,7 @@ import com.snowplowanalytics.iglu.server.model.Schema.SupersedingInfo
 import com.snowplowanalytics.iglu.server.storage.InMemory
 import com.snowplowanalytics.iglu.server.codecs.JsonCodecs._
 import com.snowplowanalytics.iglu.server.model.SchemaSpec.testSchema
-import com.snowplowanalytics.iglu.server.service.SchemaServiceSpec._
+import com.snowplowanalytics.iglu.server.SpecHelpers.SchemaKeyUri
 
 import scala.concurrent.duration.DurationLong
 

--- a/src/test/scala/com/snowplowanalytics/iglu/server/SpecHelpers.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/SpecHelpers.scala
@@ -24,6 +24,7 @@ import org.http4s._
 import org.http4s.rho.AuthedContext
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaMap, SchemaVer}
 import com.snowplowanalytics.iglu.server.model.Permission.{SchemaAction, Vendor}
+import com.snowplowanalytics.iglu.server.model.Schema.SupersedingInfo
 import model.{Permission, Schema, SchemaDraft}
 import storage.InMemory
 
@@ -53,20 +54,20 @@ object SpecHelpers {
       SchemaMap("com.acme", "event", "jsonschema", SchemaVer.Full(1, 0, 0)),
       Schema.Metadata(now, now, true),
       schemaZero,
-      None
+      SupersedingInfo.empty
     ),
     Schema(
       SchemaMap("com.acme", "event", "jsonschema", SchemaVer.Full(1, 0, 1)),
       Schema.Metadata(now, now, true),
       schemaOne,
-      None
+      SupersedingInfo.empty
     ),
     // private
     Schema(
       SchemaMap("com.acme", "secret", "jsonschema", SchemaVer.Full(1, 0, 0)),
       Schema.Metadata(now, now, false),
       schemaPrivate,
-      None
+      SupersedingInfo.empty
     )
   ).map(s => (s.schemaMap, s)).toMap
 

--- a/src/test/scala/com/snowplowanalytics/iglu/server/SpecHelpers.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/SpecHelpers.scala
@@ -74,6 +74,7 @@ object SpecHelpers {
 
   val exampleState = InMemory.State(
     schemas,
+    Map.empty,
     Map(
       superKey    -> Permission.Super,
       readKey     -> Permission.ReadOnlyAny,

--- a/src/test/scala/com/snowplowanalytics/iglu/server/model/SchemaSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/model/SchemaSpec.scala
@@ -130,7 +130,12 @@ class SchemaSpec extends org.specs2.Specification {
 
     val selfDescribingResult =
       Schema.SchemaBody.schemaBodyCirceDecoder.decodeJson(schema1) must beRight.like {
-        case Schema.SchemaBody.SelfDescribing(SelfDescribingSchema(SchemaMap(`schemaKey1`), `bodyOnlyInput`), SupersedingInfo(None, Nil)) =>
+        case Schema
+              .SchemaBody
+              .SelfDescribing(
+              SelfDescribingSchema(SchemaMap(`schemaKey1`), `bodyOnlyInput`),
+              SupersedingInfo(None, Nil)
+              ) =>
           ok
         case e => ko(s"Unexpected decoded value $e")
       }

--- a/src/test/scala/com/snowplowanalytics/iglu/server/model/SchemaSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/model/SchemaSpec.scala
@@ -15,8 +15,6 @@
 package com.snowplowanalytics.iglu.server.model
 
 import java.time.Instant
-import cats.data.NonEmptyList
-import cats.syntax.option._
 import io.circe._
 import io.circe.syntax._
 import io.circe.literal._
@@ -55,7 +53,7 @@ class SchemaSpec extends org.specs2.Specification {
         SchemaMap("me.chuwy", "test-schema", "jsonschema", SchemaVer.Full(1, 0, 0)),
         Metadata(Instant.parse("2019-01-12T22:12:54.777Z"), Instant.parse("2019-01-12T22:12:54.777Z"), true),
         json"""{"type": "object"}""",
-        None
+        SupersedingInfo.empty
       )
 
     Schema.serverSchemaDecoder.decodeJson(input) must beRight(expected)
@@ -67,10 +65,10 @@ class SchemaSpec extends org.specs2.Specification {
         SchemaMap("me.chuwy", "test-schema", "jsonschema", SchemaVer.Full(1, 0, 0)),
         Metadata(Instant.parse("2019-01-12T22:12:54.777Z"), Instant.parse("2019-01-12T22:12:54.777Z"), true),
         json"""{"type": "object"}""",
-        None
+        SupersedingInfo.empty
       )
     val schemaWithSupersededBy =
-      schemaWithoutSupersededBy.copy(supersedingInfo = Some(SupersedingInfo.SupersededBy(SchemaVer.Full(1, 0, 1))))
+      schemaWithoutSupersededBy.copy(supersedingInfo = SupersedingInfo(Some(SchemaVer.Full(1, 0, 1)), List.empty))
 
     val match1 = Schema.schemaEncoder(schemaWithSupersededBy) must beEqualTo(
       json"""
@@ -113,18 +111,18 @@ class SchemaSpec extends org.specs2.Specification {
   }
 
   def e3 = {
-    val superseding = Schema.SupersedingInfo.SupersededBy(SchemaVer.Full(1, 0, 1))
+    val superseding = Schema.SupersedingInfo(Some(SchemaVer.Full(1, 0, 1)), List.empty)
     val superseded =
-      Schema.SupersedingInfo.Supersedes(NonEmptyList.of(SchemaVer.Full(1, 0, 1), SchemaVer.Full(1, 0, 2)))
+      Schema.SupersedingInfo(None, List(SchemaVer.Full(1, 0, 1), SchemaVer.Full(1, 0, 2)))
 
     val (schema1, schemaKey1) = testSchema(SchemaVer.Full(1, 0, 0))
     val (schema2, schemaKey2) = testSchema(
       SchemaVer.Full(1, 0, 0),
-      supersedingInfo = superseding.some
+      supersedingInfo = superseding
     )
     val (schema3, schemaKey3) = testSchema(
       SchemaVer.Full(1, 0, 0),
-      supersedingInfo = superseded.some
+      supersedingInfo = superseded
     )
 
     val bodyOnlyInput = json"""{ "type": "object" }"""
@@ -132,7 +130,7 @@ class SchemaSpec extends org.specs2.Specification {
 
     val selfDescribingResult =
       Schema.SchemaBody.schemaBodyCirceDecoder.decodeJson(schema1) must beRight.like {
-        case Schema.SchemaBody.SelfDescribing(SelfDescribingSchema(SchemaMap(`schemaKey1`), `bodyOnlyInput`), None) =>
+        case Schema.SchemaBody.SelfDescribing(SelfDescribingSchema(SchemaMap(`schemaKey1`), `bodyOnlyInput`), SupersedingInfo(None, Nil)) =>
           ok
         case e => ko(s"Unexpected decoded value $e")
       }
@@ -140,7 +138,7 @@ class SchemaSpec extends org.specs2.Specification {
       Schema.SchemaBody.schemaBodyCirceDecoder.decodeJson(schema2) must beRight.like {
         case Schema
               .SchemaBody
-              .SelfDescribing(SelfDescribingSchema(SchemaMap(`schemaKey2`), `bodyOnlyInput`), Some(`superseding`)) =>
+              .SelfDescribing(SelfDescribingSchema(SchemaMap(`schemaKey2`), `bodyOnlyInput`), `superseding`) =>
           ok
         case e => ko(s"Unexpected decoded value $e")
       }
@@ -148,7 +146,7 @@ class SchemaSpec extends org.specs2.Specification {
       Schema.SchemaBody.schemaBodyCirceDecoder.decodeJson(schema3) must beRight.like {
         case Schema
               .SchemaBody
-              .SelfDescribing(SelfDescribingSchema(SchemaMap(`schemaKey3`), `bodyOnlyInput`), Some(`superseded`)) =>
+              .SelfDescribing(SelfDescribingSchema(SchemaMap(`schemaKey3`), `bodyOnlyInput`), `superseded`) =>
           ok
         case e => ko(s"Unexpected decoded value $e")
       }
@@ -170,10 +168,10 @@ class SchemaSpec extends org.specs2.Specification {
       SchemaMap("me.chuwy", "test-schema", "jsonschema", SchemaVer.Full(1, 0, 0)),
       Metadata(Instant.parse("2019-01-12T22:12:54.777Z"), Instant.parse("2019-01-12T22:12:54.777Z"), true),
       json"""{"type": "object"}""",
-      Some(SupersedingInfo.SupersededBy(SchemaVer.Full(1, 0, 1)))
+      SupersedingInfo(Some(SchemaVer.Full(1, 0, 1)), List.empty)
     )
     val reprWithSupersededBy    = Repr.Full(schema)
-    val reprWithoutSupersededBy = Repr.Full(schema.copy(supersedingInfo = None))
+    val reprWithoutSupersededBy = Repr.Full(schema.copy(supersedingInfo = SupersedingInfo.empty))
 
     val match1 = Schema.representationEncoder(reprWithSupersededBy).noSpaces must beEqualTo(
       json"""
@@ -220,9 +218,9 @@ class SchemaSpec extends org.specs2.Specification {
     )
     val reprWithSupersededBy = Repr.Canonical(
       schema,
-      Some(SupersedingInfo.SupersededBy(SchemaVer.Full(1, 0, 1)))
+      SupersedingInfo(Some(SchemaVer.Full(1, 0, 1)), List.empty)
     )
-    val reprWithoutSupersededBy = Repr.Canonical(schema, None)
+    val reprWithoutSupersededBy = Repr.Canonical(schema, SupersedingInfo.empty)
 
     val match1 = Schema.representationEncoder(reprWithSupersededBy).noSpaces must beEqualTo(
       json"""
@@ -258,18 +256,16 @@ class SchemaSpec extends org.specs2.Specification {
 object SchemaSpec {
   def testSchema(
     version: SchemaVer.Full,
-    supersedingInfo: Option[Schema.SupersedingInfo] = None,
+    supersedingInfo: Schema.SupersedingInfo = Schema.SupersedingInfo.empty,
     mergeJson: Json = JsonObject.empty.asJson
   ): (Json, SchemaKey) = {
     val schemaKey = SchemaKey("com.acme", "nonexistent", "jsonschema", version)
-    val supersedingInfoJson = supersedingInfo
-      .map {
-        case Schema.SupersedingInfo.SupersededBy(v) =>
-          json"""{ "$$supersededBy": ${v.asString} }"""
-        case Schema.SupersedingInfo.Supersedes(l) =>
-          json"""{ "$$supersedes": ${l.map(_.asString).asJson} }"""
-      }
-      .getOrElse(JsonObject.empty.asJson)
+    val supersedingInfoJson =
+      json"""
+      {
+        "$$supersededBy": ${supersedingInfo.supersededBy.map(_.asString)},
+        "$$supersedes": ${supersedingInfo.supersedes.map(_.asString).asJson}
+      }""".dropNullValues.dropEmptyValues
     val schema =
       json"""
       {

--- a/src/test/scala/com/snowplowanalytics/iglu/server/service/AuthServiceSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/service/AuthServiceSpec.scala
@@ -25,7 +25,7 @@ import com.snowplowanalytics.iglu.server.storage.InMemory
 
 class AuthServiceSpec extends org.specs2.Specification with StorageAgnosticSpec with InMemoryStorageSpec {
   def getState(request: Request[IO], superApiKey: Option[UUID] = None): IO[(List[Response[IO]], InMemory.State)] =
-    sendRequestGetState[InMemory.State](storage =>
+    sendRequestsGetState[InMemory.State](storage =>
       AuthService.asRoutes(storage, superApiKey, SpecHelpers.ctx, createRhoMiddleware())
     )(storage => storage.asInstanceOf[InMemory[IO]].ref.get)(List(request))
 

--- a/src/test/scala/com/snowplowanalytics/iglu/server/service/SchemaServiceSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/service/SchemaServiceSpec.scala
@@ -16,32 +16,46 @@ package com.snowplowanalytics.iglu.server
 package service
 
 import java.util.UUID
-
 import cats.data.NonEmptyList
 import cats.implicits._
 import cats.effect.IO
-
 import fs2.Stream
-
 import io.circe._
 import io.circe.literal._
-
 import org.http4s._
 import org.http4s.implicits._
 import org.http4s.circe._
-import org.http4s.client.Client
-import org.http4s.rho.swagger.syntax.io.createRhoMiddleware
-
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaMap, SchemaVer, SelfDescribingSchema}
 import com.snowplowanalytics.iglu.server.codecs.JsonCodecs._
 import com.snowplowanalytics.iglu.server.model.{IgluResponse, Schema}
-
 import com.snowplowanalytics.iglu.server.model.SchemaSpec.testSchema
+import com.snowplowanalytics.iglu.server.SpecHelpers.SchemaKeyUri
+import org.http4s.rho.swagger.syntax.io.createRhoMiddleware
 
-import SchemaServiceSpec._
+import java.time.Instant
 
-class SchemaServiceSpec extends org.specs2.Specification {
-  def is = s2"""
+trait SchemaServiceSpecBase extends org.specs2.Specification with StorageAgnosticSpec {
+  def sendRequests(requests: List[Request[IO]], patchesAllowed: Boolean): IO[Response[IO]] =
+    sendRequestsGetResponse(storage =>
+      SchemaService.asRoutes(patchesAllowed, Webhook.WebhookClient(List(), client))(
+        storage,
+        None,
+        SpecHelpers.ctx,
+        createRhoMiddleware()
+      )
+    )(requests)
+
+  def getState(requests: List[Request[IO]], patchesAllowed: Boolean): IO[(List[Response[IO]], List[Schema])] =
+    sendRequestGetState(storage =>
+      SchemaService.asRoutes(patchesAllowed, Webhook.WebhookClient(List(), client))(
+        storage,
+        None,
+        SpecHelpers.ctx,
+        createRhoMiddleware()
+      )
+    )(storage => storage.getSchemas)(requests)
+
+  def is = sequential ^ s2"""
   GET
     Returns 404 for non-existing schema $e1
     Returns 200 and schema for existing public schema $e3
@@ -70,7 +84,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
     val req: Request[IO] =
       Request(Method.GET, uri"/com.acme/nonexistent/jsonschema/1-0-0")
 
-    val response = SchemaServiceSpec.request(List(req), false)
+    val response = sendRequests(List(req), false)
     response.unsafeRunSync().status must beEqualTo(Status.NotFound)
   }
 
@@ -79,7 +93,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
       Request(Method.GET, uri"/com.acme/event/jsonschema/1-0-0")
 
     val result = for {
-      response <- SchemaServiceSpec.request(List(req), false)
+      response <- sendRequests(List(req), false)
       body     <- response.as[Json]
     } yield (response.status, body)
 
@@ -96,7 +110,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
       )
 
     val result = for {
-      response <- SchemaServiceSpec.request(List(req), false)
+      response <- sendRequests(List(req), false)
       body     <- response.as[Json]
     } yield (response.status, body)
 
@@ -113,7 +127,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
       )
 
     val result = for {
-      response <- SchemaServiceSpec.request(List(req), false)
+      response <- sendRequests(List(req), false)
       body     <- response.as[IgluResponse]
     } yield (response.status, body)
 
@@ -126,14 +140,24 @@ class SchemaServiceSpec extends org.specs2.Specification {
       Request(Method.GET, Uri.uri("/").withQueryParam("metadata", "1"))
 
     val result = for {
-      response <- SchemaServiceSpec.request(List(req), false)
+      response <- sendRequests(List(req), false)
       body     <- response.as[List[Schema]]
     } yield (response.status, body)
 
     val expectedBody = SpecHelpers.schemas.filter { case (_, m) => m.metadata.isPublic }.map(_._2)
+    def ignoreTimestamps(schema: Schema) =
+      schema.copy(metadata =
+        schema
+          .metadata
+          .copy(
+            createdAt = Instant.EPOCH,
+            updatedAt = Instant.EPOCH
+          )
+      )
 
     val (status, body) = result.unsafeRunSync()
-    (status must beEqualTo(Status.Ok)).and(body must beEqualTo(expectedBody))
+    (status must beEqualTo(Status.Ok))
+      .and(body.map(ignoreTimestamps) must beEqualTo(expectedBody.map(ignoreTimestamps)))
   }
 
   def e10 = {
@@ -141,7 +165,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
       Request(Method.GET, Uri.uri("/").withQueryParam("body", "1"))
 
     val result = for {
-      response <- SchemaServiceSpec.request(List(req), false)
+      response <- sendRequests(List(req), false)
       body     <- response.as[List[SelfDescribingSchema[Json]]]
     } yield (response.status, body.map(_.self))
 
@@ -160,7 +184,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
       )
 
     val result = for {
-      response <- SchemaServiceSpec.request(List(req), false)
+      response <- sendRequests(List(req), false)
       body     <- response.as[Json]
     } yield (response.status, body)
 
@@ -173,7 +197,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
       Request(Method.GET, Uri.uri("/"))
 
     val result = for {
-      response <- SchemaServiceSpec.request(List(req), false)
+      response <- sendRequests(List(req), false)
       body     <- response.as[List[SchemaKey]]
     } yield (response.status, body)
 
@@ -191,7 +215,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
       Request(Method.GET, uri"/").withHeaders(Headers.of(Header("apikey", SpecHelpers.superKey.toString)))
 
     val result = for {
-      response <- SchemaServiceSpec.request(List(req), false)
+      response <- sendRequests(List(req), false)
       body     <- response.as[List[SchemaKey]]
     } yield (response.status, body)
 
@@ -229,11 +253,12 @@ class SchemaServiceSpec extends org.specs2.Specification {
         .withHeaders(Headers.of(Header("apikey", SpecHelpers.superKey.toString)))
     )
 
-    val (requests, state) = SchemaServiceSpec.state(reqs, false).unsafeRunSync()
-    val dbExpectation = state.schemas.mapValues(s => (s.metadata.isPublic, s.body)) must havePair(
+    val (requests, schemas) = getState(reqs, false).unsafeRunSync()
+    val dbExpectation = schemas.map(s => (s.schemaMap, s.metadata.isPublic, s.body)) must contain(
       (
         SchemaMap("com.acme", "nonexistent", "jsonschema", SchemaVer.Full(1, 0, 0)),
-        (false, json"""{"type": "object"}""")
+        false,
+        json"""{"type": "object"}"""
       )
     )
     val requestExpectation = requests.lastOption.map(_.status) must beSome(Status.Ok)
@@ -283,11 +308,12 @@ class SchemaServiceSpec extends org.specs2.Specification {
         .withHeaders(Headers.of(Header("apikey", SpecHelpers.superKey.toString)))
     )
 
-    val (requests, state) = SchemaServiceSpec.state(reqs, false).unsafeRunSync()
-    val dbExpectation = state.schemas.mapValues(s => (s.metadata.isPublic, s.body)) must havePair(
+    val (requests, schemas) = getState(reqs, false).unsafeRunSync()
+    val dbExpectation = schemas.map(s => (s.schemaMap, s.metadata.isPublic, s.body)) must contain(
       (
         SchemaMap("com.acme", "nonexistent", "jsonschema", SchemaVer.Full(1, 0, 0)),
-        (false, json"""{"type": "object"}""")
+        false,
+        json"""{"type": "object"}"""
       )
     )
     val putRequestExpectation = requests.get(1).map(_.status) must beSome(Status.Conflict)
@@ -316,7 +342,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
       .withBodyStream(exampleSchema)
 
     val result = for {
-      response <- SchemaServiceSpec.request(List(req), false)
+      response <- sendRequests(List(req), false)
       body     <- response.as[Json]
     } yield (response.status, body)
 
@@ -371,11 +397,12 @@ class SchemaServiceSpec extends org.specs2.Specification {
         .withHeaders(Headers.of(Header("apikey", SpecHelpers.superKey.toString)))
     )
 
-    val (requests, state) = SchemaServiceSpec.state(reqs, true).unsafeRunSync()
-    val dbExpectation = state.schemas.mapValues(s => (s.metadata.isPublic, s.body)) must havePair(
+    val (requests, schemas) = getState(reqs, true).unsafeRunSync()
+    val dbExpectation = schemas.map(s => (s.schemaMap, s.metadata.isPublic, s.body)) must contain(
       (
         SchemaMap("com.acme", "nonexistent", "jsonschema", SchemaVer.Full(1, 0, 0)),
-        (false, json"""{"type": "object", "additionalProperties": true}""")
+        false,
+        json"""{"type": "object", "additionalProperties": true}"""
       )
     )
     val requestExpectation = requests.lastOption.map(_.status) must beSome(Status.Ok)
@@ -386,7 +413,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
     val req: Request[IO] =
       Request(Method.GET, uri"/com.acme/nonexistent/jsonschema/boom")
 
-    val response = SchemaServiceSpec.request(List(req), false)
+    val response = sendRequests(List(req), false)
 
     val result = for {
       r    <- response
@@ -432,7 +459,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
       """["iglu:com.acme/nonexistent/jsonschema/1-0-0","iglu:com.acme/nonexistent/jsonschema/1-0-1","iglu:com.acme/nonexistent/jsonschema/1-0-2","iglu:com.acme/nonexistent/jsonschema/1-1-0"]"""
 
     val result = for {
-      response <- SchemaServiceSpec.request(reqs, false)
+      response <- sendRequests(reqs, false)
       last     <- response.bodyText.compile.foldMonoid
     } yield last
 
@@ -463,7 +490,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
       .withBodyStream(exampleSchema)
 
     val result = for {
-      response <- SchemaServiceSpec.request(List(req), false)
+      response <- sendRequests(List(req), false)
       body     <- response.as[Json]
     } yield (response.status, body)
 
@@ -516,7 +543,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
     )
 
     val result = for {
-      response <- SchemaServiceSpec.request(reqs, false)
+      response <- sendRequests(reqs, false)
       body     <- response.as[Json]
     } yield (response.status, body)
 
@@ -559,7 +586,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
     )
 
     val result = for {
-      response <- SchemaServiceSpec.request(reqs, false)
+      response <- sendRequests(reqs, false)
       body     <- response.as[Json]
     } yield (response.status, body)
 
@@ -620,7 +647,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
       Request[IO](Method.GET, schemaKey102.uri).withHeaders(Headers.of(Header("apikey", SpecHelpers.superKey.toString)))
     )
 
-    val (responses, _) = SchemaServiceSpec.state(reqs, false).unsafeRunSync()
+    val (responses, _) = getState(reqs, false).unsafeRunSync()
 
     responses.reverse match {
       case r102 :: r101 :: r100 :: _ =>
@@ -694,7 +721,7 @@ class SchemaServiceSpec extends org.specs2.Specification {
     val expectedResponseStatus = List(Status.Created, Status.Created, Status.Conflict, Status.Conflict)
 
     val matchStatement = for {
-      r <- SchemaServiceSpec.state(reqs, false)
+      r <- getState(reqs, false)
       (responses, _) = r
       responseBodies <- responses.map(_.as[Json]).sequence
       responseStatus = responses.map(_.status)
@@ -705,37 +732,6 @@ class SchemaServiceSpec extends org.specs2.Specification {
   }
 }
 
-object SchemaServiceSpec {
-  import storage.InMemory
+class SchemaServiceSpec extends SchemaServiceSpecBase with InMemoryStorageSpec
 
-  implicit class SchemaKeyUri(schemaKey: SchemaKey) {
-    def uri: Uri = Uri.unsafeFromString(schemaKey.toPath)
-  }
-
-  val client: Client[IO] = Client.fromHttpApp(HttpApp[IO](r => Response[IO]().withEntity(r.body).pure[IO]))
-
-  def request(reqs: List[Request[IO]], patchesAllowed: Boolean): IO[Response[IO]] =
-    for {
-      storage <- InMemory.getInMemory[IO](SpecHelpers.exampleState)
-      service = SchemaService.asRoutes(patchesAllowed, Webhook.WebhookClient(List(), client))(
-        storage,
-        None,
-        SpecHelpers.ctx,
-        createRhoMiddleware()
-      )
-      responses <- reqs.traverse(service.run).value
-    } yield responses.flatMap(_.lastOption).getOrElse(Response(Status.NotFound))
-
-  def state(reqs: List[Request[IO]], patchesAllowed: Boolean): IO[(List[Response[IO]], InMemory.State)] =
-    for {
-      storage <- InMemory.getInMemory[IO](SpecHelpers.exampleState)
-      service = SchemaService.asRoutes(patchesAllowed, Webhook.WebhookClient(List(), client))(
-        storage,
-        None,
-        SpecHelpers.ctx,
-        createRhoMiddleware()
-      )
-      responses <- reqs.traverse(service.run).value
-      state     <- storage.ref.get
-    } yield (responses.getOrElse(List.empty), state)
-}
+class SchemaServiceSpecPostgres extends SchemaServiceSpecBase with PostgresStorageSpec

--- a/src/test/scala/com/snowplowanalytics/iglu/server/service/SchemaServiceSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/service/SchemaServiceSpec.scala
@@ -600,15 +600,14 @@ trait SchemaServiceSpecBase extends org.specs2.Specification with StorageAgnosti
     val (schema102, schemaKey102) = testSchema(SchemaVer.Full(1, 0, 2))
     val (schema103, schemaKey103) = testSchema(
       version = SchemaVer.Full(1, 0, 3),
-      supersedingInfo = Schema
-        .SupersedingInfo(
-          None,
-          List(
-            SchemaVer.Full(1, 0, 0),
-            SchemaVer.Full(1, 0, 1),
-            SchemaVer.Full(1, 0, 2)
-          )
+      supersedingInfo = Schema.SupersedingInfo(
+        None,
+        List(
+          SchemaVer.Full(1, 0, 0),
+          SchemaVer.Full(1, 0, 1),
+          SchemaVer.Full(1, 0, 2)
         )
+      )
     )
 
     val (expectedSchema100, _) = testSchema(
@@ -625,15 +624,14 @@ trait SchemaServiceSpecBase extends org.specs2.Specification with StorageAgnosti
     )
     val (expectedSchema103, _) = testSchema(
       version = SchemaVer.Full(1, 0, 3),
-      supersedingInfo = Schema
-        .SupersedingInfo(
-          None,
-          List(
-            SchemaVer.Full(1, 0, 0),
-            SchemaVer.Full(1, 0, 1),
-            SchemaVer.Full(1, 0, 2)
-          )
+      supersedingInfo = Schema.SupersedingInfo(
+        None,
+        List(
+          SchemaVer.Full(1, 0, 0),
+          SchemaVer.Full(1, 0, 1),
+          SchemaVer.Full(1, 0, 2)
         )
+      )
     )
 
     val reqs = List(

--- a/src/test/scala/com/snowplowanalytics/iglu/server/service/SchemaServiceSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/service/SchemaServiceSpec.scala
@@ -16,7 +16,6 @@ package com.snowplowanalytics.iglu.server
 package service
 
 import java.util.UUID
-import cats.data.NonEmptyList
 import cats.implicits._
 import cats.effect.IO
 import fs2.Stream
@@ -558,7 +557,7 @@ trait SchemaServiceSpecBase extends org.specs2.Specification with StorageAgnosti
     val (schema101, schemaKey101) = testSchema(SchemaVer.Full(1, 0, 1))
     val (schema100SupersededBy, _) = testSchema(
       version = SchemaVer.Full(1, 0, 0),
-      supersedingInfo = Schema.SupersedingInfo.SupersededBy(SchemaVer.Full(1, 0, 1)).some,
+      supersedingInfo = Schema.SupersedingInfo(Some(SchemaVer.Full(1, 0, 1)), List.empty),
       json"""{
         "properties": {
           "field_a": {
@@ -568,8 +567,7 @@ trait SchemaServiceSpecBase extends org.specs2.Specification with StorageAgnosti
       }"""
     )
     val (expectedSchema100, _) = testSchema(
-      version = SchemaVer.Full(1, 0, 0),
-      supersedingInfo = None
+      version = SchemaVer.Full(1, 0, 0)
     )
 
     val reqs = List(
@@ -603,41 +601,39 @@ trait SchemaServiceSpecBase extends org.specs2.Specification with StorageAgnosti
     val (schema103, schemaKey103) = testSchema(
       version = SchemaVer.Full(1, 0, 3),
       supersedingInfo = Schema
-        .SupersedingInfo
-        .Supersedes(
-          NonEmptyList.of(
+        .SupersedingInfo(
+          None,
+          List(
             SchemaVer.Full(1, 0, 0),
             SchemaVer.Full(1, 0, 1),
             SchemaVer.Full(1, 0, 2)
           )
         )
-        .some
     )
 
     val (expectedSchema100, _) = testSchema(
       version = SchemaVer.Full(1, 0, 0),
-      supersedingInfo = Schema.SupersedingInfo.SupersededBy(SchemaVer.Full(1, 0, 3)).some
+      supersedingInfo = Schema.SupersedingInfo(Some(SchemaVer.Full(1, 0, 3)), List.empty)
     )
     val (expectedSchema101, _) = testSchema(
       version = SchemaVer.Full(1, 0, 1),
-      supersedingInfo = Schema.SupersedingInfo.SupersededBy(SchemaVer.Full(1, 0, 3)).some
+      supersedingInfo = Schema.SupersedingInfo(Some(SchemaVer.Full(1, 0, 3)), List.empty)
     )
     val (expectedSchema102, _) = testSchema(
       version = SchemaVer.Full(1, 0, 2),
-      supersedingInfo = Schema.SupersedingInfo.SupersededBy(SchemaVer.Full(1, 0, 3)).some
+      supersedingInfo = Schema.SupersedingInfo(Some(SchemaVer.Full(1, 0, 3)), List.empty)
     )
     val (expectedSchema103, _) = testSchema(
       version = SchemaVer.Full(1, 0, 3),
       supersedingInfo = Schema
-        .SupersedingInfo
-        .Supersedes(
-          NonEmptyList.of(
+        .SupersedingInfo(
+          None,
+          List(
             SchemaVer.Full(1, 0, 0),
             SchemaVer.Full(1, 0, 1),
             SchemaVer.Full(1, 0, 2)
           )
         )
-        .some
     )
 
     val reqs = List(
@@ -686,11 +682,11 @@ trait SchemaServiceSpecBase extends org.specs2.Specification with StorageAgnosti
     val (schema200, schemaKey200) = testSchema(SchemaVer.Full(2, 0, 0))
     val (schema101, schemaKey101) = testSchema(
       SchemaVer.Full(1, 0, 1),
-      supersedingInfo = Schema.SupersedingInfo.Supersedes(NonEmptyList.of(SchemaVer.Full(2, 0, 0))).some
+      supersedingInfo = Schema.SupersedingInfo(None, List(SchemaVer.Full(2, 0, 0)))
     )
     val (schema101again, _) = testSchema(
       version = SchemaVer.Full(1, 0, 1),
-      supersedingInfo = Schema.SupersedingInfo.Supersedes(NonEmptyList.of(SchemaVer.Full(1, 0, 2))).some
+      supersedingInfo = Schema.SupersedingInfo(None, List(SchemaVer.Full(1, 0, 2)))
     )
 
     val reqs = List(

--- a/src/test/scala/com/snowplowanalytics/iglu/server/service/StorageAgnosticSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/service/StorageAgnosticSpec.scala
@@ -78,7 +78,7 @@ trait PostgresStorageSpec { self: StorageAgnosticSpec =>
           .schemas
           .values
           .toList
-          .map(schema => storage.addSchema(schema.schemaMap, schema.body, schema.metadata.isPublic))
+          .map(schema => storage.addSchema(schema.schemaMap, schema.body, schema.metadata.isPublic, List.empty))
           .sequence
       )
     } yield storage

--- a/src/test/scala/com/snowplowanalytics/iglu/server/service/StorageAgnosticSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/service/StorageAgnosticSpec.scala
@@ -22,7 +22,7 @@ trait StorageAgnosticSpec {
       } yield responses.flatMap(_.lastOption).getOrElse(Response(Status.NotFound))
     }
 
-  def sendRequestGetState[A](
+  def sendRequestsGetState[A](
     createService: Storage[IO] => HttpRoutes[IO]
   )(obtainState: Storage[IO] => IO[A])(requests: List[Request[IO]]): IO[(List[Response[IO]], A)] =
     storageResource.use { storage =>

--- a/src/test/scala/com/snowplowanalytics/iglu/server/service/StorageAgnosticSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/service/StorageAgnosticSpec.scala
@@ -1,0 +1,85 @@
+package com.snowplowanalytics.iglu.server.service
+
+import cats.implicits._
+import cats.effect.{ContextShift, IO, Resource, Timer}
+import com.snowplowanalytics.iglu.server.storage.{InMemory, Postgres, Storage}
+import com.snowplowanalytics.iglu.server.{Config, SpecHelpers}
+import org.http4s.{HttpApp, HttpRoutes, Request, Response, Status}
+import org.http4s.client.Client
+
+trait StorageAgnosticSpec {
+  def storageResource: Resource[IO, Storage[IO]]
+
+  val client: Client[IO] = Client.fromHttpApp(HttpApp[IO](r => Response[IO]().withEntity(r.body).pure[IO]))
+
+  def sendRequestsGetResponse(
+    createService: Storage[IO] => HttpRoutes[IO]
+  )(requests: List[Request[IO]]): IO[Response[IO]] =
+    storageResource.use { storage =>
+      val service = createService(storage)
+      for {
+        responses <- requests.traverse(service.run).value
+      } yield responses.flatMap(_.lastOption).getOrElse(Response(Status.NotFound))
+    }
+
+  def sendRequestGetState[A](
+    createService: Storage[IO] => HttpRoutes[IO]
+  )(obtainState: Storage[IO] => IO[A])(requests: List[Request[IO]]): IO[(List[Response[IO]], A)] =
+    storageResource.use { storage =>
+      val service = createService(storage)
+      for {
+        responses <- requests.traverse(service.run).value
+        state     <- obtainState(storage)
+      } yield (responses.getOrElse(List.empty), state)
+    }
+}
+
+trait InMemoryStorageSpec { self: StorageAgnosticSpec =>
+  final def storageResource: Resource[IO, Storage[IO]] =
+    Resource.eval(InMemory.getInMemory[IO](SpecHelpers.exampleState))
+}
+
+trait PostgresStorageSpec { self: StorageAgnosticSpec =>
+  import scala.concurrent.ExecutionContext.global
+  implicit val cs: ContextShift[IO] = IO.contextShift(global)
+  implicit val timer: Timer[IO]     = IO.timer(global)
+
+  val dbPoolConfig = Config
+    .StorageConfig
+    .ConnectionPool
+    .Hikari(None, None, None, None, Config.ThreadPool.Cached, Config.ThreadPool.Cached)
+
+  val storageConfig =
+    Config
+      .StorageConfig
+      .Postgres(
+        "localhost",
+        5432,
+        "testdb",
+        "postgres",
+        "iglusecret",
+        "org.postgresql.Driver",
+        None,
+        dbPoolConfig,
+        true
+      )
+
+  final def storageResource: Resource[IO, Storage[IO]] =
+    for {
+      storage <- Storage.initialize[IO](storageConfig)
+      _       <- Resource.eval(storage.asInstanceOf[Postgres[IO]].drop)
+      _       <- Resource.eval(storage.asInstanceOf[Postgres[IO]].bootstrap)
+      _ <- Resource.eval(
+        SpecHelpers.exampleState.permission.toList.map { case (key, perm) => storage.addPermission(key, perm) }.sequence
+      )
+      _ <- Resource.eval(
+        SpecHelpers
+          .exampleState
+          .schemas
+          .values
+          .toList
+          .map(schema => storage.addSchema(schema.schemaMap, schema.body, schema.metadata.isPublic))
+          .sequence
+      )
+    } yield storage
+}

--- a/src/test/scala/com/snowplowanalytics/iglu/server/service/SupersedingLogicSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/service/SupersedingLogicSpec.scala
@@ -1,0 +1,315 @@
+package com.snowplowanalytics.iglu.server.service
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.implicits._
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
+import com.snowplowanalytics.iglu.server.model.Schema.SupersedingInfo
+import com.snowplowanalytics.iglu.server.model.SchemaSpec.testSchema
+import com.snowplowanalytics.iglu.server.{SpecHelpers, Webhook}
+import com.snowplowanalytics.iglu.server.SpecHelpers.SchemaKeyUri
+import io.circe._
+import org.http4s.circe._
+import org.http4s.rho.swagger.syntax.io.createRhoMiddleware
+import org.http4s.{Header, Headers, Method, Request, Response}
+
+trait SupersedingLogicSpecBase extends org.specs2.Specification with StorageAgnosticSpec {
+  private def sendRequests(requests: List[Request[IO]]): IO[(List[Response[IO]], Unit)] =
+    sendRequestsGetState(storage =>
+      SchemaService.asRoutes(patchesAllowed = true, Webhook.WebhookClient(List(), client))(
+        storage,
+        None,
+        SpecHelpers.ctx,
+        createRhoMiddleware()
+      )
+    )(_ => IO.unit)(requests)
+
+  case class S(
+    version: (Int, Int, Int),
+    supersededBy: Option[(Int, Int, Int)] = Option.empty,
+    supersedes: List[(Int, Int, Int)] = List.empty
+  ) {
+    def encode = testSchema(
+      tripletToVersion(version),
+      supersedingInfo = (supersededBy, supersedes) match {
+        case (_, head :: tail) =>
+          Some(SupersedingInfo.Supersedes(NonEmptyList(tripletToVersion(head), tail.map(tripletToVersion))))
+        case (Some(version), _) =>
+          Some(SupersedingInfo.SupersededBy(tripletToVersion(version)))
+        case _ =>
+          None
+      }
+    )
+  }
+
+  private def tripletToVersion(version: (Int, Int, Int)) =
+    SchemaVer.Full(version._1, version._2, version._3)
+
+  private def sendReceive(schemas: List[(Json, SchemaKey)]): List[Json] = {
+    val putRequests = schemas.map {
+      case (body, key) =>
+        Request[IO](Method.PUT, key.uri)
+          .withHeaders(Headers.of(Header("apikey", SpecHelpers.superKey.toString)))
+          .withEntity(body)
+    }
+    val getRequests = schemas.map(_._2).distinct.map { key =>
+      Request[IO](Method.GET, key.uri).withHeaders(Headers.of(Header("apikey", SpecHelpers.superKey.toString)))
+    }
+    val result = for {
+      responses <- sendRequests(putRequests ::: getRequests)
+      json      <- responses._1.map(_.as[Json]).sequence
+    } yield json.drop(schemas.length)
+    result.unsafeRunSync()
+  }
+
+  private def validate(input: List[S], expected: List[S]) = {
+    // obviously
+    val logicWorks = sendReceive(input.map(_.encode)) must beEqualTo(expected.map(_.encode._1))
+
+    // the order of `supersedes` declarations should not matter
+    // let’s try to patch them in all possible permutations
+    val distinctSchemas    = input.map(_.copy(supersedes = List.empty)).distinct
+    val supersedingSchemas = input.filter(_.supersedes.nonEmpty)
+    val orderDoesNotMatter = supersedingSchemas
+      .permutations
+      .toList
+      .map { shuffled =>
+        sendReceive((distinctSchemas ::: shuffled).map(_.encode)) must beEqualTo(expected.map(_.encode._1))
+      }
+      .reduce(_.and(_))
+
+    // if we load the result into another Iglu Server,
+    // (which is what happens when promoting schemas from DEV to PROD)
+    // we should get exactly the same
+    // (note that this might be trivially true for the current implementation,
+    // but does not hurt to check)
+    val promotionWorks = sendReceive(expected.map(_.encode)) must beEqualTo(expected.map(_.encode._1))
+
+    logicWorks.and(orderDoesNotMatter).and(promotionWorks)
+  }
+
+  def is = sequential ^ s2"""
+  Basics
+    Schema version can be superseded by a newer version $e1
+    Schema version can be superseded via patching $e2
+    Schema version can’t be superseded by an older version $e3
+    Schema version can supersede multiple versions $e4
+    Schema version can supersede multiple versions via patching $e5
+  Chaining
+    If B<-A and C<-A, then C<-A $e6
+    If C<-A and B<-A, then C<-A $e7
+    If B<-A and C<-B, then C<-A and C<-B $e8
+    If C<-A and C<-B and D<-C, then D<-A and D<-B and D<-C $e9
+    If B<-A and D<-C and C<-B, then D<-A and D<-B and D<-C $e10
+    If C<-B and D<-A and B<-A, then D<-A and C<-B $e11
+    A long chain like E<-D<-C<-B<-A works $e12
+  """
+
+  def e1 = {
+    val input = List(
+      S((1, 0, 0)),
+      S((1, 0, 1), supersedes = List((1, 0, 0)))
+    )
+
+    val expected = List(
+      S((1, 0, 0), supersededBy = Some((1, 0, 1))),
+      S((1, 0, 1), supersedes = List((1, 0, 0)))
+    )
+
+    validate(input, expected)
+  }
+
+  def e2 = {
+    val input = List(
+      S((1, 0, 0)),
+      S((1, 0, 1)),
+      S((1, 0, 1), supersedes = List((1, 0, 0)))
+    )
+
+    val expected = List(
+      S((1, 0, 0), supersededBy = Some((1, 0, 1))),
+      S((1, 0, 1), supersedes = List((1, 0, 0)))
+    )
+
+    validate(input, expected)
+  }
+
+  def e3 = {
+    val input = List(
+      S((1, 0, 0)),
+      S((1, 0, 1)),
+      S((1, 0, 2)),
+      S((1, 0, 1), supersedes = List((1, 0, 2)))
+    )
+
+    val expected = List(
+      S((1, 0, 0)),
+      S((1, 0, 1)),
+      S((1, 0, 2))
+    )
+
+    validate(input, expected)
+  }
+
+  def e5 = {
+    val input = List(
+      S((1, 0, 0)),
+      S((1, 0, 1)),
+      S((1, 0, 2), supersedes = List((1, 0, 0), (1, 0, 1)))
+    )
+
+    val expected = List(
+      S((1, 0, 0), supersededBy = Some((1, 0, 2))),
+      S((1, 0, 1), supersededBy = Some((1, 0, 2))),
+      S((1, 0, 2), supersedes = List((1, 0, 0), (1, 0, 1)))
+    )
+
+    validate(input, expected)
+  }
+
+  def e4 = {
+    val input = List(
+      S((1, 0, 0)),
+      S((1, 0, 1)),
+      S((1, 0, 2), supersedes = List((1, 0, 0))),
+      S((1, 0, 2), supersedes = List((1, 0, 1)))
+    )
+
+    val expected = List(
+      S((1, 0, 0), supersededBy = Some((1, 0, 2))),
+      S((1, 0, 1), supersededBy = Some((1, 0, 2))),
+      S((1, 0, 2), supersedes = List((1, 0, 0), (1, 0, 1)))
+    )
+
+    validate(input, expected)
+  }
+
+  def e6 = {
+    val input = List(
+      S((1, 0, 0)),
+      S((1, 0, 1), supersedes = List((1, 0, 0))),
+      S((1, 0, 2), supersedes = List((1, 0, 0)))
+    )
+
+    val expected = List(
+      S((1, 0, 0), supersededBy = Some((1, 0, 2))),
+      S((1, 0, 1)),
+      S((1, 0, 2), supersedes = List((1, 0, 0)))
+    )
+
+    validate(input, expected)
+  }
+
+  def e7 = {
+    val input = List(
+      S((1, 0, 0)),
+      S((1, 0, 1)),
+      S((1, 0, 2), supersedes = List((1, 0, 0))),
+      S((1, 0, 1), supersedes = List((1, 0, 0)))
+    )
+
+    val expected = List(
+      S((1, 0, 0), supersededBy = Some((1, 0, 2))),
+      S((1, 0, 1)),
+      S((1, 0, 2), supersedes = List((1, 0, 0)))
+    )
+
+    validate(input, expected)
+  }
+
+  def e8 = {
+    val input = List(
+      S((1, 0, 0)),
+      S((1, 0, 1), supersedes = List((1, 0, 0))),
+      S((1, 0, 2), supersedes = List((1, 0, 1)))
+    )
+
+    val expected = List(
+      S((1, 0, 0), supersededBy = Some((1, 0, 2))),
+      S((1, 0, 1), supersededBy = Some((1, 0, 2))),
+      S((1, 0, 2), supersedes = List((1, 0, 0), (1, 0, 1)))
+    )
+
+    validate(input, expected)
+  }
+
+  def e9 = {
+    val input = List(
+      S((1, 0, 0)),
+      S((1, 0, 1)),
+      S((1, 0, 2), supersedes = List((1, 0, 0), (1, 0, 1))),
+      S((1, 0, 3), supersedes = List((1, 0, 2)))
+    )
+
+    val expected = List(
+      S((1, 0, 0), supersededBy = Some((1, 0, 3))),
+      S((1, 0, 1), supersededBy = Some((1, 0, 3))),
+      S((1, 0, 2), supersededBy = Some((1, 0, 3))),
+      S((1, 0, 3), supersedes = List((1, 0, 0), (1, 0, 1), (1, 0, 2)))
+    )
+
+    validate(input, expected)
+  }
+
+  def e10 = {
+    val input = List(
+      S((1, 0, 0)),
+      S((1, 0, 1), supersedes = List((1, 0, 0))),
+      S((1, 0, 2)),
+      S((1, 0, 3), supersedes = List((1, 0, 2))),
+      S((1, 0, 2), supersedes = List((1, 0, 1)))
+    )
+
+    val expected = List(
+      S((1, 0, 0), supersededBy = Some((1, 0, 3))),
+      S((1, 0, 1), supersededBy = Some((1, 0, 3))),
+      S((1, 0, 2), supersededBy = Some((1, 0, 3))),
+      S((1, 0, 3), supersedes = List((1, 0, 0), (1, 0, 1), (1, 0, 2)))
+    )
+
+    validate(input, expected)
+  }
+
+  def e11 = {
+    val input = List(
+      S((1, 0, 0)),
+      S((1, 0, 1)),
+      S((1, 0, 2), supersedes = List((1, 0, 1))),
+      S((1, 0, 3), supersedes = List((1, 0, 0))),
+      S((1, 0, 1), supersedes = List((1, 0, 0)))
+    )
+
+    val expected = List(
+      S((1, 0, 0), supersededBy = Some((1, 0, 3))),
+      S((1, 0, 1), supersededBy = Some((1, 0, 2))),
+      S((1, 0, 2), supersedes = List((1, 0, 1))),
+      S((1, 0, 3), supersedes = List((1, 0, 0)))
+    )
+
+    validate(input, expected)
+  }
+
+  def e12 = {
+    val input = List(
+      S((1, 0, 0)),
+      S((1, 0, 1), supersedes = List((1, 0, 0))),
+      S((1, 0, 2), supersedes = List((1, 0, 1))),
+      S((1, 0, 3), supersedes = List((1, 0, 2))),
+      S((1, 0, 4), supersedes = List((1, 0, 3)))
+    )
+
+    val expected = List(
+      S((1, 0, 0), supersededBy = Some((1, 0, 4))),
+      S((1, 0, 1), supersededBy = Some((1, 0, 4))),
+      S((1, 0, 2), supersededBy = Some((1, 0, 4))),
+      S((1, 0, 3), supersededBy = Some((1, 0, 4))),
+      S((1, 0, 4), supersedes = List((1, 0, 0), (1, 0, 1), (1, 0, 2), (1, 0, 3)))
+    )
+
+    validate(input, expected)
+  }
+}
+
+class SupersedingLogicSpec extends SupersedingLogicSpecBase with InMemoryStorageSpec
+
+class SupersedingLogicSpecPostgres extends SupersedingLogicSpecBase with PostgresStorageSpec

--- a/src/test/scala/com/snowplowanalytics/iglu/server/service/SupersedingLogicSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/service/SupersedingLogicSpec.scala
@@ -1,6 +1,5 @@
 package com.snowplowanalytics.iglu.server.service
 
-import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.implicits._
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
@@ -31,14 +30,7 @@ trait SupersedingLogicSpecBase extends org.specs2.Specification with StorageAgno
   ) {
     def encode = testSchema(
       tripletToVersion(version),
-      supersedingInfo = (supersededBy, supersedes) match {
-        case (_, head :: tail) =>
-          Some(SupersedingInfo.Supersedes(NonEmptyList(tripletToVersion(head), tail.map(tripletToVersion))))
-        case (Some(version), _) =>
-          Some(SupersedingInfo.SupersededBy(tripletToVersion(version)))
-        case _ =>
-          None
-      }
+      SupersedingInfo(supersededBy.map(tripletToVersion), supersedes.map(tripletToVersion))
     )
   }
 

--- a/src/test/scala/com/snowplowanalytics/iglu/server/service/SupersedingLogicSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/service/SupersedingLogicSpec.scala
@@ -71,12 +71,14 @@ trait SupersedingLogicSpecBase extends org.specs2.Specification with StorageAgno
 
   def is = sequential ^ s2"""
   Basics
-    Schema version can be superseded by a newer version $e1
+    Schema version can supersede an older version $e1
     Schema version can’t be superseded via patching $e2
-    Schema version can’t be superseded by an older version $e3
+    Schema version can’t supersede a newer version $e3a
+    Schema version can’t supersede a nonexistent version $e3b
     Schema version can supersede multiple versions $e4
   Chaining
-    If B<-A and C<-A, then C<-A $e5
+    If B<-A and C<-A, then C<-A $e5a
+    If C<-A and B<-A, then C<-A $e5b
     If B<-A and C<-B, then C<-A and C<-B $e6
     If C<-A and C<-B and D<-C, then D<-A and D<-B and D<-C $e7
     A long chain like E<-D<-C<-B<-A works $e8
@@ -111,7 +113,7 @@ trait SupersedingLogicSpecBase extends org.specs2.Specification with StorageAgno
     validate(input, expected)
   }
 
-  def e3 = {
+  def e3a = {
     val input = List(
       S((1, 0, 0)),
       S((1, 0, 1)),
@@ -123,6 +125,21 @@ trait SupersedingLogicSpecBase extends org.specs2.Specification with StorageAgno
       S((1, 0, 0)),
       S((1, 0, 1)),
       S((2, 0, 0))
+    )
+
+    validate(input, expected)
+  }
+
+  def e3b = {
+    val input = List(
+      S((1, 0, 0)),
+      S((1, 0, 1)),
+      S((2, 0, 0), supersedes = List((1, 0, 2)))
+    )
+
+    val expected = List(
+      S((1, 0, 0)),
+      S((1, 0, 1))
     )
 
     validate(input, expected)
@@ -144,7 +161,7 @@ trait SupersedingLogicSpecBase extends org.specs2.Specification with StorageAgno
     validate(input, expected)
   }
 
-  def e5 = {
+  def e5a = {
     val input = List(
       S((1, 0, 0)),
       S((1, 0, 1), supersedes = List((1, 0, 0))),
@@ -155,6 +172,22 @@ trait SupersedingLogicSpecBase extends org.specs2.Specification with StorageAgno
       S((1, 0, 0), supersededBy = Some((1, 0, 2))),
       S((1, 0, 1), supersedes = List((1, 0, 0))),
       S((1, 0, 2), supersedes = List((1, 0, 0)))
+    )
+
+    validate(input, expected)
+  }
+
+  def e5b = {
+    val input = List(
+      S((1, 0, 0)),
+      S((2, 0, 0), supersedes = List((1, 0, 0))),
+      S((1, 0, 1), supersedes = List((1, 0, 0)))
+    )
+
+    val expected = List(
+      S((1, 0, 0), supersededBy = Some((2, 0, 0))),
+      S((2, 0, 0), supersedes = List((1, 0, 0))),
+      S((1, 0, 1), supersedes = List((1, 0, 0)))
     )
 
     validate(input, expected)

--- a/src/test/scala/com/snowplowanalytics/iglu/server/service/ValidationServiceSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/service/ValidationServiceSpec.scala
@@ -28,7 +28,7 @@ import SpecHelpers.toBytes
 
 class ValidationServiceSpec extends org.specs2.Specification with StorageAgnosticSpec with InMemoryStorageSpec {
   def sendRequests(requests: List[Request[IO]]) =
-    sendRequestGetState(storage => ValidationService.asRoutes(storage, None, SpecHelpers.ctx, createRhoMiddleware()))(
+    sendRequestsGetState(storage => ValidationService.asRoutes(storage, None, SpecHelpers.ctx, createRhoMiddleware()))(
       _ => IO.unit
     )(
       requests

--- a/src/test/scala/com/snowplowanalytics/iglu/server/storage/PostgresSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/storage/PostgresSpec.scala
@@ -88,7 +88,12 @@ class PostgresSpec extends Specification with BeforeAll with IOChecker {
       check(
         Postgres
           .Sql
-          .addSchema(SchemaMap("does", "not", "exist", SchemaVer.Full(1, 0, 0)), Json.fromFields(List.empty), true)
+          .addSchema(
+            SchemaMap("does", "not", "exist", SchemaVer.Full(1, 0, 0)),
+            Json.fromFields(List.empty),
+            true,
+            List(SchemaVer.Full(1, 0, 0))
+          )
       )
     }
 

--- a/src/test/scala/com/snowplowanalytics/iglu/server/storage/PostgresSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/storage/PostgresSpec.scala
@@ -17,24 +17,20 @@ package storage
 
 import java.util.UUID
 import io.circe.Json
-
 import cats.data.NonEmptyList
 import cats.syntax.traverse._
 import cats.instances.list._
 import cats.effect.IO
-
 import doobie._
 import doobie.specs2._
 import doobie.implicits._
-
 import eu.timepit.refined.types.numeric.NonNegInt
-
 import com.snowplowanalytics.iglu.core.{SchemaMap, SchemaVer}
 import com.snowplowanalytics.iglu.server.model.{Permission, SchemaDraft}
 import com.snowplowanalytics.iglu.server.migrations.Bootstrap
+import com.snowplowanalytics.iglu.server.model.Schema.SupersedingInfo
 
 import scala.concurrent.ExecutionContext
-
 import org.specs2.mutable.Specification
 import org.specs2.specification.BeforeAll
 
@@ -131,8 +127,10 @@ class PostgresSpec extends Specification with BeforeAll with IOChecker {
           .updateSupersedingVersion(
             "vendor",
             "name",
-            NonEmptyList.of(SchemaVer.Full(1, 0, 0), SchemaVer.Full(1, 0, 2)),
-            SchemaVer.Full(1, 0, 3)
+            SupersedingInfo.Pair(
+              SchemaVer.Full(1, 0, 3),
+              NonEmptyList.of(SchemaVer.Full(1, 0, 0), SchemaVer.Full(1, 0, 2))
+            )
           )
       )
     }

--- a/src/test/scala/com/snowplowanalytics/iglu/server/storage/PostgresSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/server/storage/PostgresSpec.scala
@@ -25,10 +25,9 @@ import doobie._
 import doobie.specs2._
 import doobie.implicits._
 import eu.timepit.refined.types.numeric.NonNegInt
-import com.snowplowanalytics.iglu.core.{SchemaMap, SchemaVer}
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaMap, SchemaVer}
 import com.snowplowanalytics.iglu.server.model.{Permission, SchemaDraft}
 import com.snowplowanalytics.iglu.server.migrations.Bootstrap
-import com.snowplowanalytics.iglu.server.model.Schema.SupersedingInfo
 
 import scala.concurrent.ExecutionContext
 import org.specs2.mutable.Specification
@@ -125,12 +124,8 @@ class PostgresSpec extends Specification with BeforeAll with IOChecker {
         Postgres
           .Sql
           .updateSupersedingVersion(
-            "vendor",
-            "name",
-            SupersedingInfo.Pair(
-              SchemaVer.Full(1, 0, 3),
-              NonEmptyList.of(SchemaVer.Full(1, 0, 0), SchemaVer.Full(1, 0, 2))
-            )
+            SchemaMap(SchemaKey("vendor", "name", "jsonschema", SchemaVer.Full(1, 0, 3))),
+            NonEmptyList.of(SchemaVer.Full(1, 0, 0), SchemaVer.Full(1, 0, 2))
           )
       )
     }


### PR DESCRIPTION
In the past, Iglu Server would take both `supersededBy` and `supersedes` as inputs, and would only output `supersededBy`. This caused two problems when schemas were promoted from DEV to PROD. Suppose 1-0-3 supersedes 1-0-2.
* If 1-0-2 is in PROD and 1-0-3 is in DEV, then when 1-0-3 is copied to PROD, there will be nothing to tell the PROD Iglu Server that it supersedes 1-0-2.
* If neither are in PROD, then when 1-0-2 is copied to PROD, there will be an error because 1-0-3 is still unknown to PROD Iglu Server.

This commit changes the behavior so that:
* It’s not possible to patch superseding relationships. It’s hardly ever necessary and would create all kinds of edge cases.
* Iglu Server only takes `supersedes` as an input (that’s ok, because using `supersededBy` requires patching anyway)
* Iglu Server outputs both `supersededBy` and `supersedes` (the `supersedes` value is fixed and not updated over time, but it’s enough for the promotion logic to work correctly)